### PR TITLE
Remove 'UserIdGroupPairs" list from IP Permissions

### DIFF
--- a/definitions/awsInfrastructure.js
+++ b/definitions/awsInfrastructure.js
@@ -20,13 +20,13 @@ exports.awsWebSg = {
     GroupName: 'webSg',
     Description: 'Web security group',
     IpPermissions: [
-      { 'IpProtocol': 'tcp', 'FromPort': 3000, 'ToPort': 3000, 'UserIdGroupPairs': [], 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
-      { 'IpProtocol': 'tcp', 'FromPort': 22, 'ToPort': 22, 'UserIdGroupPairs': [], 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
-      { 'IpProtocol': 'tcp', 'FromPort': 9002, 'ToPort': 9002, 'UserIdGroupPairs': [], 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
-      { 'IpProtocol': 'tcp', 'FromPort': 873, 'ToPort': 873, 'UserIdGroupPairs': [], 'IpRanges': [ { 'CidrIp': '10.0.0.0/8' } ] },
-      { 'IpProtocol': 'tcp', 'FromPort': 9001, 'ToPort': 9001, 'UserIdGroupPairs': [], 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
-      { 'IpProtocol': 'tcp', 'FromPort': 9000, 'ToPort': 9000, 'UserIdGroupPairs': [], 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
-      { 'IpProtocol': 'tcp', 'FromPort': 8000, 'ToPort': 8000, 'UserIdGroupPairs': [], 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] }
+      { 'IpProtocol': 'tcp', 'FromPort': 3000, 'ToPort': 3000, 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
+      { 'IpProtocol': 'tcp', 'FromPort': 22, 'ToPort': 22, 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
+      { 'IpProtocol': 'tcp', 'FromPort': 9002, 'ToPort': 9002, 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
+      { 'IpProtocol': 'tcp', 'FromPort': 873, 'ToPort': 873, 'IpRanges': [ { 'CidrIp': '10.0.0.0/8' } ] },
+      { 'IpProtocol': 'tcp', 'FromPort': 9001, 'ToPort': 9001, 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
+      { 'IpProtocol': 'tcp', 'FromPort': 9000, 'ToPort': 9000, 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] },
+      { 'IpProtocol': 'tcp', 'FromPort': 8000, 'ToPort': 8000, 'IpRanges': [ { 'CidrIp': '0.0.0.0/0' } ] }
     ],
     IpPermissionsEgress: [
       { IpProtocol: '-1', UserIdGroupPairs: [], IpRanges: [ { 'CidrIp': '0.0.0.0/0' } ] } ],


### PR DESCRIPTION
Ensures compatibility with latest changes to the aws-sg-container
